### PR TITLE
Fix: null ptr ref when skip python env enabled

### DIFF
--- a/clearml_agent/commands/worker.py
+++ b/clearml_agent/commands/worker.py
@@ -3234,7 +3234,9 @@ class Worker(ServiceCommandSection):
             os.environ['PYTHONPATH'] = os.pathsep.join(filter(None, (os.environ.get('PYTHONPATH', None), python_path)))
 
         # check if we want to run as another user, only supported on linux
-        if ENV_TASK_EXECUTE_AS_USER.get() and is_linux_platform():
+        # Note: User execution requires a virtual environment, so it's disabled when 
+        # ENV_AGENT_SKIP_PYTHON_ENV_INSTALL is set
+        if ENV_TASK_EXECUTE_AS_USER.get() and is_linux_platform() and not ENV_AGENT_SKIP_PYTHON_ENV_INSTALL.get():
             command, script_dir = self._run_as_user_patch(
                 command, self._session.config_file,
                 script_dir, venv_folder,


### PR DESCRIPTION
If `run_user_as_patch` is executed with CLEARML_AGENT_SKIP_PYTHON_ENV_INSTALL=1, the job will fail referencing a NoneType. 

```
clearml_agent: ERROR: 'NoneType' object has no attribute 'as_posix'
```

This PR adds this check. 

I make the assumption that we do not run as a separate user when skipping python env setup.

Fixes: https://github.com/clearml/clearml-agent/issues/239